### PR TITLE
Disable line numbers and set statusline

### DIFF
--- a/autoload/voom.vim
+++ b/autoload/voom.vim
@@ -921,6 +921,7 @@ func! voom#TreeConfigWin() "{{{2
     setl cul nocuc nowrap nolist
     "setl winfixheight
     setl winfixwidth
+    setl nonumber
     let w:voom_tree = 'VOoM'
 endfunc
 

--- a/autoload/voom.vim
+++ b/autoload/voom.vim
@@ -922,6 +922,7 @@ func! voom#TreeConfigWin() "{{{2
     "setl winfixheight
     setl winfixwidth
     setl nonumber
+    setl statusline=VOoM\ Outliner
     let w:voom_tree = 'VOoM'
 endfunc
 


### PR DESCRIPTION
The line numbers in the outliner pane take up vertical screen space. I would suggest that they be disabled.

Also, the statusline usually contains information like filename, filetype, modified flags. These information are not very useful in the outliner pane. Setting the statusline to "VOoM Outliner" can at least show the user that the buffer is a VOoM pane.

Thansk for developing such a useful plugin!
