### PR TITLE
ENH: g:voom_nofoldenable=1 to not fold lines of the Tree buffer

### DIFF
--- a/autoload/voom.vim
+++ b/autoload/voom.vim
@@ -965,10 +965,14 @@ endfunc
 
 func! voom#TreeConfigWin() "{{{2
 " Tree window-local options.
-    setl foldenable
-    setl foldtext=getline(v:foldstart).'\ \ \ /'.(v:foldend-v:foldstart)
-    setl foldmethod=expr
-    setl foldexpr=voom#TreeFoldexpr(v:lnum)
+    if exists("g:voom_nofoldenable") && (g:voom_nofoldenable == 1)
+        setl nofoldenable
+    else
+        setl foldenable
+        setl foldtext=getline(v:foldstart).'\ \ \ /'.(v:foldend-v:foldstart)
+        setl foldmethod=expr
+        setl foldexpr=voom#TreeFoldexpr(v:lnum)
+    endif
     setl cul nocuc nowrap nolist
     "setl winfixheight
     setl winfixwidth

--- a/doc/voom.txt
+++ b/doc/voom.txt
@@ -908,6 +908,17 @@ g:voom_rstrip_chars_{filetype}   ~
         let g:voom_rstrip_chars_text = " \t"
         let g:voom_rstrip_chars_help = " \t"
 
+g:voom_nofoldenable   ~
+    If set to 1, the Tree buffer will be initialized with `set nofoldenable`.
+    Default is 0.
+    Usage:
+        # let g:voom_nofoldenable = 0  # Default. (Do set foldenable)
+        let g:voom_nofoldenable   = 1  # (Set nofoldenable)
+    After changing g:voom_nofoldenable, the Tree buffer must be closed
+    and reopened:
+        <c-w>h
+        :q
+        :Voom
 
 g:voom_user_command   ~
     This option allows to execute an arbitrary user-defined command when


### PR DESCRIPTION
- [ ] I had a strange foldexpr warning that may have been due to modelines, idk. It may be better to set all the fold options regardless of nofoldenable or not?

Otherwise, this seems to work here with minimal manual testing.
```vim
let g:voom_nofoldenable=1
```